### PR TITLE
翻译placement 2.16

### DIFF
--- a/docs/source/cn/__init__.py
+++ b/docs/source/cn/__init__.py
@@ -29,3 +29,4 @@ from .autograd_mode import *
 from .reshape import *
 from .utils import *
 from .norm import *
+from .placement import *

--- a/docs/source/cn/placement.py
+++ b/docs/source/cn/placement.py
@@ -30,20 +30,13 @@ oneflow.placement.__doc__ =  r"""
     oneflow.placement 可以通过以下几种方式构造：
 
     .. code-block:: python
-
         >>> import oneflow as flow
         
-        >>> p = flow.placement("cuda", {0:range(4)})
+        >>> p = flow.placement("cuda", ranks=[0, 1, 2, 3])
         >>> p
-        oneflow.placement(device_type="cuda", machine_device_ids={0 : [0, 1, 2, 3]}, hierarchy=(4,))
-        >>> p = flow.placement("cuda", {0:range(4)}, (2, 2))
+        oneflow.placement(type="cuda", ranks=[0, 1, 2, 3])
+        >>> p = flow.placement("cuda", ranks=[[0, 1], [2, 3]])
         >>> p
-        oneflow.placement(device_type="cuda", machine_device_ids={0 : [0, 1, 2, 3]}, hierarchy=(2, 2))
-        >>> p = flow.placement("cpu", {0:[0, 1], 1:[2, 3]}, (4,))
-        >>> p
-        oneflow.placement(device_type="cpu", machine_device_ids={0 : [0, 1], 1 : [2, 3]}, hierarchy=(4,))
-        >>> p = flow.placement("cpu", {0:[0, 1, 2, 3]}, (2, 2))
-        >>> p
-        oneflow.placement(device_type="cpu", machine_device_ids={0 : [0, 1, 2, 3]}, hierarchy=(2, 2))
+        oneflow.placement(type="cuda", ranks=[[0, 1], [2, 3]])
 
 """

--- a/docs/source/cn/placement.py
+++ b/docs/source/cn/placement.py
@@ -1,0 +1,49 @@
+import oneflow
+from docreset import reset_docstr
+
+reset_docstr(
+    oneflow.env.all_device_placement,
+    r"""
+    返回 env 下所有的机器的所有设备的 placement。
+
+    参数：
+        - **device_type** (str): cuda 或者 cpu
+
+    示例：
+
+    .. code-block:: python
+
+        # world_size = 4, node_size = 1
+        import oneflow as flow
+        
+        p = flow.env.all_device_placement("cuda") # oneflow.placement(device_type="cuda", machine_device_ids={0 : [0, 1, 2, 3]}, hierarchy=(4,))
+        p = flow.env.all_device_placement("cpu") # oneflow.placement(device_type="cpu", machine_device_ids={0 : [0, 1, 2, 3]}, hierarchy=(4,))
+
+    """
+)
+
+oneflow.placement.__doc__ =  r"""
+    oneflow.placement 是一个对象，用于指代一个 oneflow.Tensor 被分配或即将被分配到的设备组。oneflow.placement 包含一个设备类型 ('cpu' 或者 'cuda') 和对应的设备序列。
+
+    oneflow.Tensor 的 placement 可以通过 Tensor.placement 访问。
+
+    oneflow.placement 可以通过以下几种方式构造：
+
+    .. code-block:: python
+
+        >>> import oneflow as flow
+        
+        >>> p = flow.placement("cuda", {0:range(4)})
+        >>> p
+        oneflow.placement(device_type="cuda", machine_device_ids={0 : [0, 1, 2, 3]}, hierarchy=(4,))
+        >>> p = flow.placement("cuda", {0:range(4)}, (2, 2))
+        >>> p
+        oneflow.placement(device_type="cuda", machine_device_ids={0 : [0, 1, 2, 3]}, hierarchy=(2, 2))
+        >>> p = flow.placement("cpu", {0:[0, 1], 1:[2, 3]}, (4,))
+        >>> p
+        oneflow.placement(device_type="cpu", machine_device_ids={0 : [0, 1], 1 : [2, 3]}, hierarchy=(4,))
+        >>> p = flow.placement("cpu", {0:[0, 1, 2, 3]}, (2, 2))
+        >>> p
+        oneflow.placement(device_type="cpu", machine_device_ids={0 : [0, 1, 2, 3]}, hierarchy=(2, 2))
+
+"""

--- a/docs/source/cn/placement.py
+++ b/docs/source/cn/placement.py
@@ -29,7 +29,6 @@ oneflow.placement.__doc__ =  r"""
 
     oneflow.placement 可以通过以下几种方式构造：
 
-    .. code-block:: python
         >>> import oneflow as flow
         
         >>> p = flow.placement("cuda", ranks=[0, 1, 2, 3])

--- a/docs/source/cn/placement.py
+++ b/docs/source/cn/placement.py
@@ -28,7 +28,9 @@ oneflow.placement.__doc__ =  r"""
     oneflow.Tensor 的 placement 可以通过 Tensor.placement 访问。
 
     oneflow.placement 可以通过以下几种方式构造：
-
+    
+    .. code-block:: python
+    
         >>> import oneflow as flow
         
         >>> p = flow.placement("cuda", ranks=[0, 1, 2, 3])


### PR DESCRIPTION
紧急翻译完成了oneflow.placement和另一个算子。

[oneflow.placement](https://github.com/Oneflow-Inc/oneflow/blob/7d34a3abdb9b170d9db59212f8e2591ed0960e98/python/oneflow/framework/docstr/placement.py#L19) 和 [oneflow.env.all_device_placement](https://github.com/Oneflow-Inc/oneflow/blob/93887884683d478e8f2fe96ed0a9ebc08a227c88/python/oneflow/framework/env_util.py#L33)

![image](https://user-images.githubusercontent.com/92694420/154205716-79886147-7c30-4ad3-a8b3-db9c4d7e61b9.png)
