### PR TITLE
optim 剩余部分

### DIFF
--- a/docs/source/cn/__init__.py
+++ b/docs/source/cn/__init__.py
@@ -42,3 +42,10 @@ from .adam import *
 from .adamw import *
 from .lamb import *
 from .optimizer import *
+from .rmsprop import *
+from .sgd import *
+from .cosine_decay_lr import *
+from .cosine_annealing_lr import *
+from .exponential_lr import *
+from .multistep_lr import *
+from .lambda_lr import *

--- a/docs/source/cn/__init__.py
+++ b/docs/source/cn/__init__.py
@@ -50,4 +50,7 @@ from .cosine_annealing_lr import *
 from .exponential_lr import *
 from .multistep_lr import *
 from .lambda_lr import *
-
+from .multistep_lr import *
+from .polynomial_lr import *
+from .reduce_lr_on_plateau import *
+from .step_lr import *

--- a/docs/source/cn/adagrad.py
+++ b/docs/source/cn/adagrad.py
@@ -3,7 +3,7 @@ from docreset import reset_docstr
 
 reset_docstr(
     oneflow.optim.Adagrad,
-    r"""实现 Adagrad 优化器。 
+    r"""实现 Adagrad 优化算法。 
 
         公式是: 
 

--- a/docs/source/cn/cosine_annealing_lr.py
+++ b/docs/source/cn/cosine_annealing_lr.py
@@ -26,7 +26,7 @@ reset_docstr(
         \eta_t = \eta_{min} + \frac{1}{2}(\eta_{max} - \eta_{min})\left(1 +
         \cos\left(\frac{T_{cur}}{T_{max}}\pi\right)\right)
 
-    它在 `SGDR: Stochastic Gradient Descent with Warm Restarts`_ 中被提出。
+    这在 `SGDR: Stochastic Gradient Descent with Warm Restarts`_ 中被提出。
     请注意，这只实现了 SGDR 的 cosine annealing 部分，并不包括重新启动。
 
     参数:

--- a/docs/source/cn/cosine_annealing_lr.py
+++ b/docs/source/cn/cosine_annealing_lr.py
@@ -1,0 +1,43 @@
+import oneflow
+from docreset import reset_docstr
+
+reset_docstr(
+    oneflow.optim.lr_scheduler.CosineAnnealingLR,
+    r"""
+    文档参考自： https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.CosineAnnealingLR.html?highlight=cosine#torch.optim.lr_scheduler.CosineAnnealingLR
+
+    使用 cosine annealing schedule 设置每个参数组的学习率，其中 :math:`\eta_{max}` 被设置为初始学学习率，
+    :math:`T_{cur}` 是自 SGDR 中最后一次重启以来的 epoch 数。
+
+    .. math::
+        \begin{aligned}
+            \eta_t & = \eta_{min} + \frac{1}{2}(\eta_{max} - \eta_{min})\left(1
+            + \cos\left(\frac{T_{cur}}{T_{max}}\pi\right)\right),
+            & T_{cur} \neq (2k+1)T_{max}; \\
+            \eta_{t+1} & = \eta_{t} + \frac{1}{2}(\eta_{max} - \eta_{min})
+            \left(1 - \cos\left(\frac{1}{T_{max}}\pi\right)\right),
+            & T_{cur} = (2k+1)T_{max}.
+        \end{aligned}
+
+    当 last_step=-1， 设置初始学习率为 lr。因为时间表是递归定义的， 在这个学习率调整器之外，它也可以同时被其他操作者修改。
+    如果学习率完全由这个调整器设定，每一步的学习率就变成了：
+
+    .. math::
+        \eta_t = \eta_{min} + \frac{1}{2}(\eta_{max} - \eta_{min})\left(1 +
+        \cos\left(\frac{T_{cur}}{T_{max}}\pi\right)\right)
+
+    它在 `SGDR: Stochastic Gradient Descent with Warm Restarts`_ 中被提出。
+    请注意，这只实现了 SGDR 的 cosine annealing 部分，而不是重新启动。
+
+    参数:
+        - **optimizer** (Optimizer) - 封装的优化器。
+        - **T_max** (int) - 迭代的最大数量。
+        - **eta_min** (float) - 学习率的最小值，默认值：0。
+        - **last_step** (int) - 最后一个 epoch 的索引，默认值：-1。
+        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到 stdout，默认值: ``False`` 。
+
+    .. _SGDR\: Stochastic Gradient Descent with Warm Restarts:
+        https://arxiv.org/abs/1608.03983
+    """
+)
+

--- a/docs/source/cn/cosine_annealing_lr.py
+++ b/docs/source/cn/cosine_annealing_lr.py
@@ -40,10 +40,3 @@ reset_docstr(
         https://arxiv.org/abs/1608.03983
     """
 )
-
-reset_docstr(
-    oneflow.optim.lr_scheduler.CosineAnnealingLR.get_lr,
-    """
-    利用学习率调整器链式计算学习率。
-    """
-)

--- a/docs/source/cn/cosine_annealing_lr.py
+++ b/docs/source/cn/cosine_annealing_lr.py
@@ -41,3 +41,9 @@ reset_docstr(
     """
 )
 
+reset_docstr(
+    oneflow.optim.lr_scheduler.CosineAnnealingLR.get_lr,
+    """
+    利用学习率调整器链式计算学习率。
+    """
+)

--- a/docs/source/cn/cosine_annealing_lr.py
+++ b/docs/source/cn/cosine_annealing_lr.py
@@ -19,7 +19,7 @@ reset_docstr(
             & T_{cur} = (2k+1)T_{max}.
         \end{aligned}
 
-    当 last_step=-1， 设置初始学习率为 lr。因为时间表是递归定义的， 在这个学习率调整器之外，它也可以同时被其他操作者修改。
+    当 last_step=-1， 设置初始学习率为 lr。因为调整是递归定义的， 除学习率调整器之外，它也可以同时被其他算子修改。
     如果学习率完全由这个调整器设定，每一步的学习率就变成了：
 
     .. math::
@@ -27,10 +27,10 @@ reset_docstr(
         \cos\left(\frac{T_{cur}}{T_{max}}\pi\right)\right)
 
     它在 `SGDR: Stochastic Gradient Descent with Warm Restarts`_ 中被提出。
-    请注意，这只实现了 SGDR 的 cosine annealing 部分，而不是重新启动。
+    请注意，这只实现了 SGDR 的 cosine annealing 部分，并不包括重新启动。
 
     参数:
-        - **optimizer** (Optimizer) - 封装的优化器。
+        - **optimizer** (Optimizer) - 被包装的优化器。
         - **T_max** (int) - 迭代的最大数量。
         - **eta_min** (float) - 学习率的最小值，默认值：0。
         - **last_step** (int) - 最后一个 epoch 的索引，默认值：-1。

--- a/docs/source/cn/cosine_annealing_lr.py
+++ b/docs/source/cn/cosine_annealing_lr.py
@@ -34,7 +34,7 @@ reset_docstr(
         - **T_max** (int) - 迭代的最大数量。
         - **eta_min** (float) - 学习率的最小值，默认值：0。
         - **last_step** (int) - 最后一个 epoch 的索引，默认值：-1。
-        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到 stdout，默认值: ``False`` 。
+        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到标准输出，默认值: ``False`` 。
 
     .. _SGDR\: Stochastic Gradient Descent with Warm Restarts:
         https://arxiv.org/abs/1608.03983

--- a/docs/source/cn/cosine_decay_lr.py
+++ b/docs/source/cn/cosine_decay_lr.py
@@ -29,7 +29,7 @@ reset_docstr(
         - **decay_steps** (int) - 学习率调整器中 decay steps。
         - **alpha** (float, optional) - 学习率比例因子（ :math:`\\alpha` ）（默认值： 0.0）。
         - **last_step** (int) - 最后一个 epoch 的索引，默认值：-1。
-        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到 stdout，默认值: ``False`` 。
+        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到标准输出，默认值: ``False`` 。
 
     示例：
 

--- a/docs/source/cn/cosine_decay_lr.py
+++ b/docs/source/cn/cosine_decay_lr.py
@@ -48,9 +48,4 @@ reset_docstr(
     """
 )
 
-reset_docstr(
-    oneflow.optim.lr_scheduler.CosineDecayLR.get_lr,
-    """
-    利用学习率调整器链式计算学习率。
-    """
-)
+

--- a/docs/source/cn/cosine_decay_lr.py
+++ b/docs/source/cn/cosine_decay_lr.py
@@ -25,7 +25,7 @@ reset_docstr(
     请注意，这里只实现了 SGDR 的 cosine annealing 部分，而不是重新启动。
 
     参数：
-        - **optimizer** (Optimizer) - 封装的优化器。
+        - **optimizer** (Optimizer) - 被包装的优化器。
         - **decay_steps** (int) - 学习率调整器中 decay steps。
         - **alpha** (float, optional) - 学习率比例因子（ :math:`\\alpha` ）（默认值： 0.0）。
         - **last_step** (int) - 最后一个 epoch 的索引，默认值：-1。

--- a/docs/source/cn/cosine_decay_lr.py
+++ b/docs/source/cn/cosine_decay_lr.py
@@ -1,0 +1,49 @@
+import oneflow
+from docreset import reset_docstr
+
+reset_docstr(
+    oneflow.optim.lr_scheduler.CosineDecayLR,
+    """这个算子构建了一个 Cosine decayed 学习率调整器。
+
+    在用户指定 decay_steps 之前，学习率将被更新为：
+
+    .. math::
+
+        & cos\\_decay = 0.5*(1+cos(\\pi*\\frac{current\\_step}{decay\\_steps}))
+
+        & decay\\_factor = (1-\\alpha)*cos\\_decay+\\alpha
+
+        & learning\\_rate = base\\_learning\\_rate*decay\\_factor
+
+    在用户指定 decay_steps 之后，学习率将是：
+
+    .. math::
+
+        learning\\_rate = {base\\_learning\\_rate}*{\\alpha}
+
+    它在 `SGDR: Stochastic Gradient Descent with Warm Restarts`_ 中被提出。
+    请注意，这里只实现了 SGDR 的 cosine annealing 部分，而不是重新启动。
+
+    参数：
+        - **optimizer** (Optimizer) - 封装的优化器。
+        - **decay_steps** (int) - 学习率调整器中 decay steps。
+        - **alpha** (float, optional) - 学习率比例因子（ :math:`\\alpha` ）（默认值： 0.0）。
+        - **last_step** (int) - 最后一个 epoch 的索引，默认值：-1。
+        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到 stdout，默认值: ``False`` 。
+
+    示例：
+
+    .. code-block:: python
+
+        import oneflow as flow
+
+        ...
+        cosine_decay_lr = flow.optim.lr_scheduler.CosineDecayLR(optimizer, decay_steps=100, alpha=0.0)
+        for epoch in range(num_epoch):
+            train(...)
+            cosine_decay_lr.step()
+
+    .. _SGDR\\: Stochastic Gradient Descent with Warm Restarts:
+        https://arxiv.org/abs/1608.03983
+    """
+)

--- a/docs/source/cn/cosine_decay_lr.py
+++ b/docs/source/cn/cosine_decay_lr.py
@@ -47,3 +47,10 @@ reset_docstr(
         https://arxiv.org/abs/1608.03983
     """
 )
+
+reset_docstr(
+    oneflow.optim.lr_scheduler.CosineDecayLR.get_lr,
+    """
+    利用学习率调整器链式计算学习率。
+    """
+)

--- a/docs/source/cn/cosine_decay_lr.py
+++ b/docs/source/cn/cosine_decay_lr.py
@@ -3,9 +3,9 @@ from docreset import reset_docstr
 
 reset_docstr(
     oneflow.optim.lr_scheduler.CosineDecayLR,
-    """这个算子构建了一个 Cosine decayed 学习率调整器。
+    """此算子构建了一个 Cosine decayed 学习率调整器。
 
-    在用户指定 decay_steps 之前，学习率将被更新为：
+    在用户指定的 decay_steps 之前，学习率被更新为：
 
     .. math::
 
@@ -15,21 +15,21 @@ reset_docstr(
 
         & learning\\_rate = base\\_learning\\_rate*decay\\_factor
 
-    在用户指定 decay_steps 之后，学习率将是：
+    在用户指定的 decay_steps 之后，学习率被更新为：
 
     .. math::
 
         learning\\_rate = {base\\_learning\\_rate}*{\\alpha}
 
-    它在 `SGDR: Stochastic Gradient Descent with Warm Restarts`_ 中被提出。
-    请注意，这里只实现了 SGDR 的 cosine annealing 部分，而不是重新启动。
+    这在 `SGDR: Stochastic Gradient Descent with Warm Restarts`_ 中被提出。
+    请注意，这里只实现了 SGDR 的 cosine annealing 部分，并不包括重新启动。
 
     参数：
         - **optimizer** (Optimizer) - 被包装的优化器。
         - **decay_steps** (int) - 学习率调整器中 decay steps。
-        - **alpha** (float, optional) - 学习率比例因子（ :math:`\\alpha` ）（默认值： 0.0）。
+        - **alpha** (float, optional) - 学习率比例因子( :math:`\\alpha` )，默认值为 0.0。
         - **last_step** (int) - 最后一个 epoch 的索引，默认值：-1。
-        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到标准输出，默认值: ``False`` 。
+        - **verbose** (bool) - 如果为 ``True`` ，则会在每次更新时打印一条信息到标准输出。默认为 ``False``。
 
     示例：
 
@@ -47,5 +47,3 @@ reset_docstr(
         https://arxiv.org/abs/1608.03983
     """
 )
-
-

--- a/docs/source/cn/exponential_lr.py
+++ b/docs/source/cn/exponential_lr.py
@@ -16,9 +16,3 @@ reset_docstr(
     """
 )
 
-reset_docstr(
-    oneflow.optim.lr_scheduler.ExponentialLR.get_lr,
-    """
-    利用学习率调整器链式计算学习率。
-    """
-)

--- a/docs/source/cn/exponential_lr.py
+++ b/docs/source/cn/exponential_lr.py
@@ -15,3 +15,10 @@ reset_docstr(
 
     """
 )
+
+reset_docstr(
+    oneflow.optim.lr_scheduler.ExponentialLR.get_lr,
+    """
+    利用学习率调整器链式计算学习率。
+    """
+)

--- a/docs/source/cn/exponential_lr.py
+++ b/docs/source/cn/exponential_lr.py
@@ -1,0 +1,17 @@
+import oneflow
+from docreset import reset_docstr
+
+reset_docstr(
+    oneflow.optim.lr_scheduler.ExponentialLR,
+    """
+    在每个 epoch 中以 gamma 衰减每个参数组的学习率。
+    当 last_epoch=- 1时，设置初始学习率为 lr。
+
+    参数：
+        - **optimizer** (Optimizer) - 封装的优化器。
+        - **gamma** (float) - 学习率衰减的乘法系数。
+        - **last_step** (int) - 最后一个 epoch 的索引，默认值：-1。
+        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到 stdout，默认值: ``False`` 。
+
+    """
+)

--- a/docs/source/cn/exponential_lr.py
+++ b/docs/source/cn/exponential_lr.py
@@ -4,14 +4,14 @@ from docreset import reset_docstr
 reset_docstr(
     oneflow.optim.lr_scheduler.ExponentialLR,
     """
-    在每个 epoch 中以 gamma 衰减每个参数组的学习率。
+    在每个 epoch 中根据 gamma 衰减每个参数组的学习率。
     当 last_epoch=- 1时，设置初始学习率为 lr。
 
     参数：
-        - **optimizer** (Optimizer) - 封装的优化器。
+        - **optimizer** (Optimizer) - 被包装的优化器。
         - **gamma** (float) - 学习率衰减的乘法系数。
         - **last_step** (int) - 最后一个 epoch 的索引，默认值：-1。
-        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到 stdout，默认值: ``False`` 。
+        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到标准输出，默认值: ``False`` 。
 
     """
 )

--- a/docs/source/cn/exponential_lr.py
+++ b/docs/source/cn/exponential_lr.py
@@ -4,15 +4,13 @@ from docreset import reset_docstr
 reset_docstr(
     oneflow.optim.lr_scheduler.ExponentialLR,
     """
-    在每个 epoch 中根据 gamma 衰减每个参数组的学习率。
-    当 last_epoch=- 1时，设置初始学习率为 lr。
+    在每个 epoch 中对每个参数组的学习率进行伽玛衰减操作。
+    当 last_step = -1 时，设置初始学习率为 lr。
 
     参数：
         - **optimizer** (Optimizer) - 被包装的优化器。
         - **gamma** (float) - 学习率衰减的乘法系数。
         - **last_step** (int) - 最后一个 epoch 的索引，默认值：-1。
-        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到标准输出，默认值: ``False`` 。
-
+        - **verbose** (bool) - 如果为 ``True`` ，则会在每次更新时打印一条信息到标准输出。默认为 ``False``。
     """
 )
-

--- a/docs/source/cn/lambda_lr.py
+++ b/docs/source/cn/lambda_lr.py
@@ -5,7 +5,7 @@ reset_docstr(
     oneflow.optim.lr_scheduler.LambdaLR,
     """
     将每个参数组的学习率设置为给定函数的初始 lr 倍。
-    当 last_epoch=- 1时，设置初始学习率为 lr。
+    当 last_step = -1 时，设置初始学习率为 lr。
 
     .. math::
 
@@ -13,9 +13,9 @@ reset_docstr(
 
     参数：
         - **optimizer** (Optimizer) - 被包装的优化器。
-        - **lr_lambda** (function or list) - 一个根据给定参数 epoch 计算乘法因子的函数，或为一组函数，其中每个函数用于 optimizer.param_groups 中的每一个组。或者一个此类函数的列表，一个在每组 optimizer.param_groups 中。
+        - **lr_lambda** (function or list) - 一个根据给定参数 epoch 计算乘法因子的函数，或为一组函数，其中每个函数用于 optimizer.param_groups 中的每一个组。
         - **last_step** (int) - 最后一个 epoch 的索引（默认值：-1）。
-        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到标准输出（默认值: ``False`` ）。
+        - **verbose** (bool) - 如果为 ``True`` ，则会在每次更新时打印一条信息到标准输出。默认为 ``False``。
 
     示例：
 
@@ -45,9 +45,9 @@ reset_docstr(
 
 reset_docstr(
     oneflow.optim.lr_scheduler.LambdaLR.state_dict,
-    """ 以 :class:`dict` 形式返回调整器的状态。
+    """ 以 :class:`dict` 类型返回调整器的状态。
 
-        它包含了 self.__dict__ 中每个不是优化器的变量的条目。
-        学习率 lambda 函数只有在它们是可调用的对象时才会被保存，如果它们是函数或 lambdas 则不会被保存。
+        它包含了 self.__dict__ 中每个变量不是优化器的条目。
+        学习率 lambda 函数只有在它们是可调用的对象时才会被保存，如果是函数或 lambdas 则不会被保存。
         """
 )

--- a/docs/source/cn/lambda_lr.py
+++ b/docs/source/cn/lambda_lr.py
@@ -34,3 +34,21 @@ reset_docstr(
 
     """
 )
+
+reset_docstr(
+    oneflow.optim.lr_scheduler.LambdaLR.load_state_dict,
+    """加载调整器的状态。
+
+        参数：
+            - **state_dict** (dict) - 调整器的状态，应为调用 :meth:`state_dict` 函数所返回的对象。
+        """
+)
+
+reset_docstr(
+    oneflow.optim.lr_scheduler.LambdaLR.state_dict,
+    """ 以 :class:`dict` 形式返回调整器的状态。
+
+        它包含了 self.__dict__ 中每个变量的条目，而这些变量并不是优化器。
+        学习率 lambda 函数只有在它们是可调用的对象时才会被保存，如果它们是函数或 lambdas 则不会被保存。
+        """
+)

--- a/docs/source/cn/lambda_lr.py
+++ b/docs/source/cn/lambda_lr.py
@@ -1,0 +1,36 @@
+import oneflow
+from docreset import reset_docstr
+
+reset_docstr(
+    oneflow.optim.lr_scheduler.LambdaLR,
+    """
+    将每个参数组的学习率设置为初始 lr 乘一个给定的函数。
+    当 last_epoch=- 1时，设置初始学习率为 lr。
+
+    .. math::
+
+        learning\\_rate = base\\_learning\\_rate*lambda(last\\_step)
+
+    参数：
+        - **optimizer** (Optimizer) - 封装的优化器。
+        - **lr_lambda**(function or list) - 一个给定整数参数 epoch 的计算乘法因子的函数，
+            或者一个此类函数的列表，一个在每组 optimizer.param_groups 中。
+        - **last_step** (int) - 最后一个 epoch 的索引（默认值：-1）。
+        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到 stdout（默认值: ``False`` ）。
+
+    示例：
+
+    .. code-block:: python
+
+        import oneflow as flow
+
+        ...
+        lambda1 = lambda step: step // 30
+        lambda2 = lambda step: 0.95 * step
+        lambda_lr = flow.optim.lr_scheduler.LambdaLR(optimizer, [lambda1, lambda2])
+        for epoch in range(num_epoch):
+            train(...)
+            lambda_lr.step()
+
+    """
+)

--- a/docs/source/cn/lambda_lr.py
+++ b/docs/source/cn/lambda_lr.py
@@ -4,7 +4,7 @@ from docreset import reset_docstr
 reset_docstr(
     oneflow.optim.lr_scheduler.LambdaLR,
     """
-    将每个参数组的学习率设置为初始 lr 乘一个给定的函数。
+    将每个参数组的学习率设置为给定函数的初始 lr 倍。
     当 last_epoch=- 1时，设置初始学习率为 lr。
 
     .. math::
@@ -12,8 +12,8 @@ reset_docstr(
         learning\\_rate = base\\_learning\\_rate*lambda(last\\_step)
 
     参数：
-        - **optimizer** (Optimizer) - 封装的优化器。
-        - **lr_lambda** (function or list) - 一个给定整数参数 epoch 的计算乘法因子的函数，
+        - **optimizer** (Optimizer) - 被包装的优化器。
+        - **lr_lambda** (function or list) - 一个根据给定参数 epoch 计算乘法因子的函数，或为一组函数，其中每个函数用于 optimizer.param_groups 中的每一个组。
             或者一个此类函数的列表，一个在每组 optimizer.param_groups 中。
         - **last_step** (int) - 最后一个 epoch 的索引（默认值：-1）。
         - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到 stdout（默认值: ``False`` ）。
@@ -48,7 +48,7 @@ reset_docstr(
     oneflow.optim.lr_scheduler.LambdaLR.state_dict,
     """ 以 :class:`dict` 形式返回调整器的状态。
 
-        它包含了 self.__dict__ 中每个变量的条目，而这些变量并不是优化器。
+        它包含了 self.__dict__ 中每个不是优化器的变量的条目。
         学习率 lambda 函数只有在它们是可调用的对象时才会被保存，如果它们是函数或 lambdas 则不会被保存。
         """
 )

--- a/docs/source/cn/lambda_lr.py
+++ b/docs/source/cn/lambda_lr.py
@@ -13,8 +13,7 @@ reset_docstr(
 
     参数：
         - **optimizer** (Optimizer) - 被包装的优化器。
-        - **lr_lambda** (function or list) - 一个根据给定参数 epoch 计算乘法因子的函数，或为一组函数，其中每个函数用于 optimizer.param_groups 中的每一个组。
-            或者一个此类函数的列表，一个在每组 optimizer.param_groups 中。
+        - **lr_lambda** (function or list) - 一个根据给定参数 epoch 计算乘法因子的函数，或为一组函数，其中每个函数用于 optimizer.param_groups 中的每一个组。或者一个此类函数的列表，一个在每组 optimizer.param_groups 中。
         - **last_step** (int) - 最后一个 epoch 的索引（默认值：-1）。
         - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到标准输出（默认值: ``False`` ）。
 

--- a/docs/source/cn/lambda_lr.py
+++ b/docs/source/cn/lambda_lr.py
@@ -16,7 +16,7 @@ reset_docstr(
         - **lr_lambda** (function or list) - 一个根据给定参数 epoch 计算乘法因子的函数，或为一组函数，其中每个函数用于 optimizer.param_groups 中的每一个组。
             或者一个此类函数的列表，一个在每组 optimizer.param_groups 中。
         - **last_step** (int) - 最后一个 epoch 的索引（默认值：-1）。
-        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到 stdout（默认值: ``False`` ）。
+        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到标准输出（默认值: ``False`` ）。
 
     示例：
 

--- a/docs/source/cn/lambda_lr.py
+++ b/docs/source/cn/lambda_lr.py
@@ -13,7 +13,7 @@ reset_docstr(
 
     参数：
         - **optimizer** (Optimizer) - 封装的优化器。
-        - **lr_lambda**(function or list) - 一个给定整数参数 epoch 的计算乘法因子的函数，
+        - **lr_lambda** (function or list) - 一个给定整数参数 epoch 的计算乘法因子的函数，
             或者一个此类函数的列表，一个在每组 optimizer.param_groups 中。
         - **last_step** (int) - 最后一个 epoch 的索引（默认值：-1）。
         - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到 stdout（默认值: ``False`` ）。

--- a/docs/source/cn/multistep_lr.py
+++ b/docs/source/cn/multistep_lr.py
@@ -4,15 +4,15 @@ from docreset import reset_docstr
 reset_docstr(
     oneflow.optim.lr_scheduler.MultiStepLR,
     """
-    一旦步数达到一个临界值，每个参数组的学习率就会以 gamma 衰减。请注意，这种衰减可能与来自本调整器之外的其他学习率变化同时发生。
-    当 last_epoch =- 1时，设置初始学习率为 lr。
+    一旦步数达到一个临界值，对每个参数组的学习率进行伽玛衰减操作。注意，这种衰减可以与其他因素导致的学习率变化同时发生。
+    当 last_step = -1 时，设置初始学习率为 lr。
 
     参数：
         - **optimizer** (Optimizer) - 被包装的优化器。
-        - **milestones** (list) - step indices 的 list，必须是增加的。
+        - **milestones** (list) - step indices 的 list，必须是递增的。
         - **gamma** (float, optional) - 学习率衰减的乘法系数（默认值：0.1）。
         - **last_step** (int) - 最后一个 epoch 的索引（默认值：-1）。
-        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到标准输出（默认值: ``False`` ）。
+        - **verbose** (bool) - 如果为 ``True`` ，则会在每次更新时打印一条信息到标准输出。默认为 ``False``。
 
     示例：
 
@@ -28,5 +28,3 @@ reset_docstr(
 
     """
 )
-
-

--- a/docs/source/cn/multistep_lr.py
+++ b/docs/source/cn/multistep_lr.py
@@ -1,0 +1,30 @@
+import oneflow
+from docreset import reset_docstr
+
+reset_docstr(
+    oneflow.optim.lr_scheduler.MultiStepLR,
+    """
+    一旦步数达到一个临界值，每个参数组的学习率就会以 gamma 衰减。请注意，这种衰减可能与来自本调整器之外的其他学习率变化同时发生。
+    当 last_epoch=- 1时，设置初始学习率为 lr。
+
+    参数：
+        - **optimizer** (Optimizer) - 封装的优化器。
+        - **milestones**(list) - step indices 的 list，必须是增加的。
+        - **gamma** (float, optional) - 学习率衰减的乘法系数（默认值：0.1）。
+        - **last_step** (int) - 最后一个 epoch 的索引（默认值：-1）。
+        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到 stdout（默认值: ``False`` ）。
+
+    示例：
+
+    .. code-block:: python
+
+        import oneflow as flow
+
+        ...
+        multistep_lr = flow.optim.lr_scheduler.MultiStepLR(optimizer, milestones=[30,80], gamma=0.1)
+        for epoch in range(num_epoch):
+            train(...)
+            multistep_lr.step()
+
+    """
+)

--- a/docs/source/cn/multistep_lr.py
+++ b/docs/source/cn/multistep_lr.py
@@ -26,5 +26,12 @@ reset_docstr(
             train(...)
             multistep_lr.step()
 
-    """,
+    """
+)
+
+reset_docstr(
+    oneflow.optim.lr_scheduler.MultiStepLR.get_lr,
+    """
+    利用学习率调整器链式计算学习率。
+    """
 )

--- a/docs/source/cn/multistep_lr.py
+++ b/docs/source/cn/multistep_lr.py
@@ -9,7 +9,7 @@ reset_docstr(
 
     参数：
         - **optimizer** (Optimizer) - 封装的优化器。
-        - **milestones**(list) - step indices 的 list，必须是增加的。
+        - **milestones** (list) - step indices 的 list，必须是增加的。
         - **gamma** (float, optional) - 学习率衰减的乘法系数（默认值：0.1）。
         - **last_step** (int) - 最后一个 epoch 的索引（默认值：-1）。
         - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到 stdout（默认值: ``False`` ）。
@@ -26,5 +26,5 @@ reset_docstr(
             train(...)
             multistep_lr.step()
 
-    """
+    """,
 )

--- a/docs/source/cn/multistep_lr.py
+++ b/docs/source/cn/multistep_lr.py
@@ -5,14 +5,14 @@ reset_docstr(
     oneflow.optim.lr_scheduler.MultiStepLR,
     """
     一旦步数达到一个临界值，每个参数组的学习率就会以 gamma 衰减。请注意，这种衰减可能与来自本调整器之外的其他学习率变化同时发生。
-    当 last_epoch=- 1时，设置初始学习率为 lr。
+    当 last_epoch =- 1时，设置初始学习率为 lr。
 
     参数：
-        - **optimizer** (Optimizer) - 封装的优化器。
+        - **optimizer** (Optimizer) - 被包装的优化器。
         - **milestones** (list) - step indices 的 list，必须是增加的。
         - **gamma** (float, optional) - 学习率衰减的乘法系数（默认值：0.1）。
         - **last_step** (int) - 最后一个 epoch 的索引（默认值：-1）。
-        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到 stdout（默认值: ``False`` ）。
+        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到标准输出（默认值: ``False`` ）。
 
     示例：
 

--- a/docs/source/cn/multistep_lr.py
+++ b/docs/source/cn/multistep_lr.py
@@ -29,9 +29,4 @@ reset_docstr(
     """
 )
 
-reset_docstr(
-    oneflow.optim.lr_scheduler.MultiStepLR.get_lr,
-    """
-    利用学习率调整器链式计算学习率。
-    """
-)
+

--- a/docs/source/cn/polynomial_lr.py
+++ b/docs/source/cn/polynomial_lr.py
@@ -4,7 +4,7 @@ from docreset import reset_docstr
 reset_docstr(
     oneflow.optim.lr_scheduler.PolynomialLR,
     r"""
-    这个算子创建了一个多项式衰减学习率的调整器。学习率将被更新如下：
+    此算子创建了一个多项式形式的学习率衰减调整器。学习率按如下方式更新：
 
     如果 cycle 为 `True` ，则等式为：
 
@@ -27,7 +27,7 @@ reset_docstr(
         - **steps** (int) - 衰减的步数。
         - **end_learning_rate** (float, optional) - 最终学习率，默认值为 0.0001。
         - **power** (float, optional) - 多项式的幂，默认为 1.0。
-        - **cycle** (bool, optional) - 如果 cycle 为 True，调整器将在每一个衰减步骤中衰减学习率，默认值为 False。
+        - **cycle** (bool, optional) - 如果 cycle 为 True，调整器将在每一步中衰减学习率，默认值为 False。
    
     示例：
 
@@ -45,4 +45,3 @@ reset_docstr(
 
     """
 )
-

--- a/docs/source/cn/polynomial_lr.py
+++ b/docs/source/cn/polynomial_lr.py
@@ -1,0 +1,55 @@
+import oneflow
+from docreset import reset_docstr
+
+reset_docstr(
+    oneflow.optim.lr_scheduler.PolynomialLR,
+    r"""
+    这个算子创建了一个多项式衰减学习率的调整器。学习率将被更新如下：
+
+    如果 cycle 为 `True` ，则等式为：
+
+    .. math::
+        \begin{aligned}
+           & decay\_batch = decay\_batch*ceil(\frac{current\_batch}{decay\_batch}) \\
+           & learning\_rate = (base\_lr-end\_lr)*(1-\frac{current\_batch}{decay\_batch})^{power}+end\_lr
+        \end{aligned}
+
+    如果 cycle 为 `False` ，则等式为：
+
+    .. math::
+        \begin{aligned}
+           & decay\_batch = min(decay\_batch, current\_batch) \\
+           & learning\_rate = (base\_lr-end\_lr)*(1-\frac{current\_batch}{decay\_batch})^{power}+end\_lr
+        \end{aligned}
+
+    参数:
+        - **optimizer** (Optimizer) - 封装的优化器。
+        - **steps** (int) - decayed steps。
+        - **end_learning_rate** (float, optional) - 最终学习率，默认值为 0.0001。
+        - **power** (float, optional) - 多项式的幂，默认为 1.0。
+        - **cycle** (bool, optional) - 如果 cycle 为 True，调整器将在每一个 decay step 中衰减学习率，默认值为 False。
+   
+    示例：
+
+    .. code-block:: python
+
+        import oneflow as flow
+       
+        ... 
+        polynomial_scheduler = flow.optim.lr_scheduler.PolynomialLR(
+            optimizer, steps=5, end_learning_rate=0.00001, power=2
+            )
+        for epoch in range(num_epoch):
+            train(...)
+            polynomial_scheduler.step()
+
+    """
+)
+
+reset_docstr(
+    oneflow.optim.lr_scheduler.PolynomialLR.get_lr,
+    """
+    利用学习率调整器链式计算学习率。
+    """
+)
+

--- a/docs/source/cn/polynomial_lr.py
+++ b/docs/source/cn/polynomial_lr.py
@@ -46,10 +46,3 @@ reset_docstr(
     """
 )
 
-reset_docstr(
-    oneflow.optim.lr_scheduler.PolynomialLR.get_lr,
-    """
-    利用学习率调整器链式计算学习率。
-    """
-)
-

--- a/docs/source/cn/polynomial_lr.py
+++ b/docs/source/cn/polynomial_lr.py
@@ -24,10 +24,10 @@ reset_docstr(
 
     参数:
         - **optimizer** (Optimizer) - 被包装的优化器。
-        - **steps** (int) - decayed steps。
+        - **steps** (int) - 衰减的步数。
         - **end_learning_rate** (float, optional) - 最终学习率，默认值为 0.0001。
         - **power** (float, optional) - 多项式的幂，默认为 1.0。
-        - **cycle** (bool, optional) - 如果 cycle 为 True，调整器将在每一个 decay step 中衰减学习率，默认值为 False。
+        - **cycle** (bool, optional) - 如果 cycle 为 True，调整器将在每一个衰减步骤中衰减学习率，默认值为 False。
    
     示例：
 

--- a/docs/source/cn/polynomial_lr.py
+++ b/docs/source/cn/polynomial_lr.py
@@ -23,7 +23,7 @@ reset_docstr(
         \end{aligned}
 
     参数:
-        - **optimizer** (Optimizer) - 封装的优化器。
+        - **optimizer** (Optimizer) - 被包装的优化器。
         - **steps** (int) - decayed steps。
         - **end_learning_rate** (float, optional) - 最终学习率，默认值为 0.0001。
         - **power** (float, optional) - 多项式的幂，默认为 1.0。

--- a/docs/source/cn/reduce_lr_on_plateau.py
+++ b/docs/source/cn/reduce_lr_on_plateau.py
@@ -9,7 +9,7 @@ reset_docstr(
     学习率就会降低。
 
     参数:
-        - **optimizer** (Optimizer) - 封装的优化器。
+        - **optimizer** (Optimizer) - 被包装的优化器。
         - **mode** (str) - `min` 或者 `max` 。在 `min` 模式中，当监测的数量不再减少时学习率将会减小；
             在 `max` 模式中，当监测的数量不再增加时学习率将会减小。默认： `min` 。
         - **factor** (float) - 学习率降低的系数， new_lr = lr * factor ， 默认值：0.1。

--- a/docs/source/cn/reduce_lr_on_plateau.py
+++ b/docs/source/cn/reduce_lr_on_plateau.py
@@ -4,21 +4,21 @@ from docreset import reset_docstr
 reset_docstr(
     oneflow.optim.lr_scheduler.ReduceLROnPlateau,
     """当一个 metric 停止更新时，降低学习率。
-    一旦学习停滞不前，模型通常会从降低2-10倍的学习率中受益。
-    这个调整器读取一个指标量，如果在 'patience' 的 epoch 数中没有看到改进，
-    学习率就会降低。
+    一旦学习停滞不前，降低 2-10 倍的学习率往往能有效改善。
+    这个调整器每读取一个指标量，如果没有在第 'patience' 轮学习中看到改进，
+    就会降低学习率。
 
     参数:
         - **optimizer** (Optimizer) - 被包装的优化器。
-        - **mode** (str) - `min` 或者 `max` 。在 `min` 模式中，当监测的数量不再减少时学习率将会减小；在 `max` 模式中，当监测的数量不再增加时学习率将会减小。默认： `min` 。
+        - **mode** (str) - `min` 或者 `max` 。在 `min` 模式中，当被监测的数量不再减少时学习率将会减小；在 `max` 模式中，当被监测的数量不再增加时学习率将会减小。默认为 `min`。
         - **factor** (float) - 学习率降低的系数， new_lr = lr * factor ， 默认值：0.1。
-        - **patience** (int) - 不会再改善模型的 epoch 数，在这之后学习率将降低。例如，如果 `patience = 2` ，那么我们会忽略前两个没有改善的 epoch ，如果 loss 仍然没有减小，学习率也将会在第三个 epoch 后减小，默认值：10。
+        - **patience** (int) - 若在这个 epoch 中模型还没有改善，学习率将降低。例如，如果 `patience = 2` ，那么我们会忽略前两个没有改善的 epoch ，如果此后 loss 仍然没有减小，学习率也将会在第三个 epoch 后减小。默认值：10。
         - **threshold** (float) - 测量新的最佳状态的阈值，只关注一些重要变化。默认：1e-4。
-        - **threshold_mode** (str) - `rel` 或 `abs` 。 在 `rel` 模式中， 'max' ：dynamic_threshold = best * ( 1 + threshold )， 'min' ：dynamic_threshold = best * ( 1 - threshold )； 在 `abs` 模式中，`max` ：dynamic_threshold = best + threshold， `min` ：dynamic_threshold = best - threshold inmode。默认： `rel` 。
+        - **threshold_mode** (str) - `rel` 或 `abs` 。 在 `rel` 模式中，（max）dynamic_threshold = best * ( 1 + threshold )，（min）dynamic_threshold = best * ( 1 - threshold )； 在 `abs` 模式中，（max）dynamic_threshold = best + threshold，（min）dynamic_threshold = best - threshold inmode。默认： `rel` 。
         - **cooldown** (int) - 学习率减少后，在恢复正常操作前要等待的 epoch 数，默认值：0。
-        - **min_lr** (float or list) - 一个标量或一个标量列表，分别是所有参数组或每组的学习率下限，默认：0。
-        - **eps** (float) - 适用于学习率的最小衰减，如果新旧学习率之间的差异小于 eps，更新将被忽略。默认值：1e-8。
-        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到标准输出，默认值: ``False`` 。
+        - **min_lr** (float or list) - 一个标量或一个标量列表，分别是所有参数组和每组的学习率下限，默认：0。
+        - **eps** (float) - 应用于学习率的最小衰减，如果新旧学习率之间的差异小于 eps，更新将被忽略。默认值：1e-8。
+        - **verbose** (bool) - 如果为 ``True`` ，则会在每次更新时打印一条信息到标准输出。默认为 ``False``。
 
     示例:
     
@@ -60,4 +60,3 @@ reset_docstr(
 
         """
 )
-

--- a/docs/source/cn/reduce_lr_on_plateau.py
+++ b/docs/source/cn/reduce_lr_on_plateau.py
@@ -10,24 +10,15 @@ reset_docstr(
 
     参数:
         - **optimizer** (Optimizer) - 被包装的优化器。
-        - **mode** (str) - `min` 或者 `max` 。在 `min` 模式中，当监测的数量不再减少时学习率将会减小；
-            在 `max` 模式中，当监测的数量不再增加时学习率将会减小。默认： `min` 。
+        - **mode** (str) - `min` 或者 `max` 。在 `min` 模式中，当监测的数量不再减少时学习率将会减小；在 `max` 模式中，当监测的数量不再增加时学习率将会减小。默认： `min` 。
         - **factor** (float) - 学习率降低的系数， new_lr = lr * factor ， 默认值：0.1。
-        - **patience** (int) - 不会再改善模型的 epoch 数，在这之后学习率将降低。
-            例如，如果 `patience = 2` ，那么我们会忽略前两个没有改善的 epoch ，
-            如果 loss 仍然没有减小，学习率也将会在第三个 epoch 后减小，
-            默认值：10。
+        - **patience** (int) - 不会再改善模型的 epoch 数，在这之后学习率将降低。例如，如果 `patience = 2` ，那么我们会忽略前两个没有改善的 epoch ，如果 loss 仍然没有减小，学习率也将会在第三个 epoch 后减小，默认值：10。
         - **threshold** (float) - 测量新的最佳状态的阈值，只关注一些重要变化。默认：1e-4。
-        - **threshold_mode** (str) - `rel` 或 `abs` 。 在 `rel` 模式中，
-            'max' ：dynamic_threshold = best * ( 1 + threshold )，
-            'min' ：dynamic_threshold = best * ( 1 - threshold )； 
-            在 `abs` 模式中，`max` ：dynamic_threshold = best + threshold，
-            `min` ：dynamic_threshold = best - threshold inmode。默认： `rel` 。
+        - **threshold_mode** (str) - `rel` 或 `abs` 。 在 `rel` 模式中， 'max' ：dynamic_threshold = best * ( 1 + threshold )， 'min' ：dynamic_threshold = best * ( 1 - threshold )； 在 `abs` 模式中，`max` ：dynamic_threshold = best + threshold， `min` ：dynamic_threshold = best - threshold inmode。默认： `rel` 。
         - **cooldown** (int) - 学习率减少后，在恢复正常操作前要等待的 epoch 数，默认值：0。
-        - **min_lr** (float or list) - 一个标量或一个标量列表，
-            分别是所有参数组或每组的学习率下限，默认：0。
+        - **min_lr** (float or list) - 一个标量或一个标量列表，分别是所有参数组或每组的学习率下限，默认：0。
         - **eps** (float) - 适用于学习率的最小衰减，如果新旧学习率之间的差异小于 eps，更新将被忽略。默认值：1e-8。
-        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到 stdout，默认值: ``False`` 。
+        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到标准输出，默认值: ``False`` 。
 
     示例:
     

--- a/docs/source/cn/reduce_lr_on_plateau.py
+++ b/docs/source/cn/reduce_lr_on_plateau.py
@@ -1,0 +1,71 @@
+import oneflow
+from docreset import reset_docstr
+
+reset_docstr(
+    oneflow.optim.lr_scheduler.ReduceLROnPlateau,
+    """当一个 metric 停止更新时，降低学习率。
+    一旦学习停滞不前，模型通常会从降低2-10倍的学习率中受益。
+    这个调整器读取一个指标量，如果在 'patience' 的 epoch 数中没有看到改进，
+    学习率就会降低。
+
+    参数:
+        - **optimizer** (Optimizer) - 封装的优化器。
+        - **mode** (str) - `min` 或者 `max` 。在 `min` 模式中，当监测的数量不再减少时学习率将会减小；
+            在 `max` 模式中，当监测的数量不再增加时学习率将会减小。默认： 'min' 。
+        - **factor** (float) - 学习率降低的系数， new_lr = lr * factor ， 默认值：0.1。
+        - **patience** (int) - 不会再改善模型的 epoch 数，在这之后学习率将降低。
+            例如，如果 `patience = 2` ，那么我们会忽略前两个没有改善的 epoch ，
+            如果 loss 仍然没有减小，学习率也将会在第三个 epoch 后减小，
+            默认值：10。
+        - **threshold** (float) - 测量新的最佳状态的阈值，只关注一些重要变化。默认：1e-4。
+        - **threshold_mode** (str) - `rel` 或 `abs` 。 在 `rel` 模式中，
+            'max' ：dynamic_threshold = best * ( 1 + threshold )，
+            'min' ：dynamic_threshold = best * ( 1 - threshold )； 
+            在 `abs` 模式中，`max` ：dynamic_threshold = best + threshold，
+            `min` ：dynamic_threshold = best - threshold inmode。默认： 'rel' 。
+        - **cooldown** (int) - 学习率减少后，在恢复正常操作前要等待的 epoch 数，默认值：0。
+        - **min_lr** (float or list) - 一个标量或一个标量列表，
+            分别是所有参数组或每组的学习率下限，默认：0。
+        - **eps** (float) - 适用于学习率的最小衰减，
+            如果新旧学习旅之间的差异小于 eps，更新将被忽略。默认值：1e-8。
+        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到 stdout，默认值: ``False`` 。
+
+    示例:
+    
+    .. code-block:: python
+
+        optimizer = flow.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
+        scheduler = flow.optim.lr_scheduler.ReduceLROnPlateau(optimizer, 'min')
+        for epoch in range(10):
+            train(...)
+            val_loss = validate(...)
+            # 注意，该步骤应在validate()之后调用。
+            scheduler.step(val_loss)
+    """
+)
+
+reset_docstr(
+    oneflow.optim.lr_scheduler.ReduceLROnPlateau.load_state_dict,
+    """加载调整器的状态。
+
+        参数：
+            - **state_dict** (dict) - 调整器的状态，应为调用 :meth:`state_dict` 函数所返回的对象。
+        """
+)
+
+reset_docstr(
+    oneflow.optim.lr_scheduler.ReduceLROnPlateau.state_dict,
+    """ 以 :class:`dict` 形式返回调整器的状态。
+
+        它包含了 self.__dict__ 中每个变量的条目，而这些变量并不是优化器。
+        """
+)
+
+reset_docstr(
+    oneflow.optim.lr_scheduler.ReduceLROnPlateau.step,
+    """Step forward once.
+
+        Arguments:
+            metrics (float): a metrics quantity of Measuring the effect of model training.
+        """
+)

--- a/docs/source/cn/reduce_lr_on_plateau.py
+++ b/docs/source/cn/reduce_lr_on_plateau.py
@@ -11,7 +11,7 @@ reset_docstr(
     参数:
         - **optimizer** (Optimizer) - 封装的优化器。
         - **mode** (str) - `min` 或者 `max` 。在 `min` 模式中，当监测的数量不再减少时学习率将会减小；
-            在 `max` 模式中，当监测的数量不再增加时学习率将会减小。默认： 'min' 。
+            在 `max` 模式中，当监测的数量不再增加时学习率将会减小。默认： `min` 。
         - **factor** (float) - 学习率降低的系数， new_lr = lr * factor ， 默认值：0.1。
         - **patience** (int) - 不会再改善模型的 epoch 数，在这之后学习率将降低。
             例如，如果 `patience = 2` ，那么我们会忽略前两个没有改善的 epoch ，
@@ -22,12 +22,11 @@ reset_docstr(
             'max' ：dynamic_threshold = best * ( 1 + threshold )，
             'min' ：dynamic_threshold = best * ( 1 - threshold )； 
             在 `abs` 模式中，`max` ：dynamic_threshold = best + threshold，
-            `min` ：dynamic_threshold = best - threshold inmode。默认： 'rel' 。
+            `min` ：dynamic_threshold = best - threshold inmode。默认： `rel` 。
         - **cooldown** (int) - 学习率减少后，在恢复正常操作前要等待的 epoch 数，默认值：0。
         - **min_lr** (float or list) - 一个标量或一个标量列表，
             分别是所有参数组或每组的学习率下限，默认：0。
-        - **eps** (float) - 适用于学习率的最小衰减，
-            如果新旧学习旅之间的差异小于 eps，更新将被忽略。默认值：1e-8。
+        - **eps** (float) - 适用于学习率的最小衰减，如果新旧学习率之间的差异小于 eps，更新将被忽略。默认值：1e-8。
         - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到 stdout，默认值: ``False`` 。
 
     示例:
@@ -63,9 +62,11 @@ reset_docstr(
 
 reset_docstr(
     oneflow.optim.lr_scheduler.ReduceLROnPlateau.step,
-    """Step forward once.
+    """执行单个优化步骤。
 
-        Arguments:
-            metrics (float): a metrics quantity of Measuring the effect of model training.
+        参数:
+            - **metrics** (float)- 一个衡量模型训练效果的指标量。
+
         """
 )
+

--- a/docs/source/cn/rmsprop.py
+++ b/docs/source/cn/rmsprop.py
@@ -5,7 +5,7 @@ reset_docstr(
     oneflow.optim.RMSprop,
     """实现 RMSprop 优化算法。
 
-    Root Mean Squared Propagation (RMSProp) 是一种未发表的、自适应的学习率方法。最初的构想提出了 RMSProp，在
+    Root Mean Squared Propagation (RMSProp) 是一种未发表的、自适应的学习率方法。最先提出了 RMSProp 的构想出现在
     http://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf 的第29页。
 
     原始方程如下：
@@ -17,7 +17,7 @@ reset_docstr(
         W = w - \\frac{\\eta} {\\\\sqrt{r(w,t) + \\epsilon}} \\nabla Q_{i}(w)
 
     第一个方程计算了每个权重的梯度平方的移动平均值。然后将梯度除以 :math:`sqrt{v(w,t)}`.
-    在一些情况下，加入一个 momentum 项 :math: `\\beta` 是很有效的。在这个优化算法实现的过程中，使用了 Nesterov momentum:
+    在一些情况下，加入一个动量项 :math:`\\beta` 是很有效的。OneFlow 的实现中采用了 Nesterov 加速方法：
 
     .. math::
 
@@ -42,7 +42,7 @@ reset_docstr(
         w = w - v(w, t)
 
     其中 :math:`\\alpha` 是一个超参数，其典型值为 0.99， 0.95 等等。 :math:`\\beta` 是一个 momentum 项。
-    :math:`\\epsilon` 是一个 smoothing 项，以避免被零整除，通常设置的范围在 1e-4 到 1e-8。
+    :math:`\\epsilon` 是一个 smoothing 项，用来避免被零整除，通常设置在 1e-4 到 1e-8 的范围内。
 
 
     参数:
@@ -96,7 +96,7 @@ reset_docstr(
 
     若要使用 clip_grad 函数，请参考这个示例。
 
-    关于 `clip_grad_max_norm` 和 `clip_grad_norm_type` 函数的更多细节，请参考 :func:`oneflow.nn.utils.clip_grad_norm` 。
+    关于 `clip_grad_max_norm_` 和 `clip_grad_norm_type` 函数的更多细节，请参考 :func:`oneflow.nn.utils.clip_grad_norm` 。
 
     """
 )

--- a/docs/source/cn/rmsprop.py
+++ b/docs/source/cn/rmsprop.py
@@ -1,0 +1,112 @@
+import oneflow
+from docreset import reset_docstr
+
+reset_docstr(
+    oneflow.optim.RMSprop,
+    """实现 RMSprop 优化算法。
+
+    Root Mean Squared Propagation (RMSProp) 是一种未发表的、自适应的学习率方法。最初的构想提出了 RMSProp，在
+    http://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf 的第29页。
+
+    原始方程如下：
+
+    .. math::
+
+        r(w, t) = \\alpha r(w, t-1) + (1 - \\alpha)(\\nabla Q_{i}(w))^2
+
+        W = w - \\frac{\\eta} {\\\\sqrt{r(w,t) + \\epsilon}} \\nabla Q_{i}(w)
+
+    第一个方程计算了每个权重的梯度平方的移动平均值。然后将梯度除以 :math:`sqrt{v(w,t)}`.
+    在一些情况下，加入一个 momentum 项 :math: `\\beta` 是很有效的。在这个优化算法实现的过程中，使用了 Nesterov momentum:
+
+    .. math::
+
+        r(w, t) = \\alpha r(w, t-1) + (1 - \\alpha)(\\nabla Q_{i}(w))^2
+
+        v(w, t) = \\beta v(w, t-1) + \\frac{\\eta} {\\\\sqrt{r(w,t) +
+            \\epsilon}} \\nabla Q_{i}(w)
+
+        w = w - v(w, t)
+
+    如果 centered 为 True:
+
+    .. math::
+
+        r(w, t) = \\alpha r(w, t-1) + (1 - \\alpha)(\\nabla Q_{i}(w))^2
+
+        g(w, t) = \\alpha g(w, t-1) + (1 - \\alpha)\\nabla Q_{i}(w)
+
+        v(w, t) = \\beta v(w, t-1) + \\frac{\\eta} {\\\\sqrt{r(w,t) - (g(w, t))^2 +
+            \\epsilon}} \\nabla Q_{i}(w)
+
+        w = w - v(w, t)
+
+    其中 :math:`\\alpha` 是一个超参数，其典型值为 0.99， 0.95 等等。 :math:`\\beta` 是一个 momentum 项。
+    :math:`\\epsilon` 是一个 smoothing 项，以避免被零整除，通常设置的范围在 1e-4 到 1e-8。
+
+
+    参数:
+        - **params** (iterable) - 待优化参数构成的 iterable 或定义了参数组的 dict。
+        - **lr** (float, optional) - 学习率（默认值：1e-2）。 
+        - **momentum** (float, optional) - momentum 因子（默认值: 0, oneflow 现在不支持 momenmtum > 0）。
+        - **alpha** (float, optional) - smoothing 常量（默认值: 0.99）。
+        - **eps** (float, optional) - 添加到分母中以提高数值稳定性的项（默认值：1e-8）。
+        - **centered** (bool, optional) - 如果为 ``True`` ， 计算 centered RMSProp，梯度通过对其方差的估计进行标准化处理。
+        - **weight_decay** (float, optional) - 权重衰减（L2 penalty）（默认值: 0）。
+
+    示例: 
+
+    例 1: 
+
+    .. code-block:: python 
+
+        # 假设 net 是一个自定义模型。 
+        rmsprop = flow.optim.RMSprop(net.parameters(), lr=1e-3)
+
+        for epoch in range(epochs):
+            # 读取数据，计算损失，等等。
+            # ...
+            loss.backward()
+            rmsprop.step()
+            rmsprop.zero_grad()
+
+    例 2: 
+
+    .. code-block:: python 
+
+        # 假设 net 是一个自定义模型。 
+        rmsprop = flow.optim.RMSprop(
+            [
+                {
+                    "params": net.parameters(),
+                    "lr": learning_rate,
+                    "clip_grad_max_norm": 0.5,
+                    "clip_grad_norm_type": 2.0,
+                }
+            ],
+        )
+
+        for epoch in range(epochs):
+            # 读取数据，计算损失，等等。
+            # ...
+            loss.backward()
+            rmsprop.clip_grad()
+            rmsprop.step()
+            rmsprop.zero_grad()
+
+    若要使用 clip_grad 函数，请参考这个示例。
+
+    关于 `clip_grad_max_norm` 和 `clip_grad_norm_type` 函数的更多细节，请参考 :func:`oneflow.nn.utils.clip_grad_norm` 。
+
+    """
+)
+
+reset_docstr(
+    oneflow.optim.RMSprop.step,
+    """执行一个优化步骤。
+
+        参数:
+            - **closure** (callable, optional) - 重新测试模型并返回损失的闭包。
+        """
+)
+

--- a/docs/source/cn/sgd.py
+++ b/docs/source/cn/sgd.py
@@ -1,0 +1,76 @@
+import oneflow
+from docreset import reset_docstr
+
+reset_docstr(
+    oneflow.optim.SGD,
+    """实现 SGD 优化算法。
+
+    该算法将随机样本的梯度作为小批量梯度下降中整体梯度的近似估计。
+
+    当 momentum = 0，参数的更新方程为：
+
+        .. math::
+
+            param_{new} = param_{old} - learning\\_rate * grad
+
+    当有了 momentum，参数的更新方程为：
+
+        .. math::
+
+            & V_t = \\beta * V_{t-1} - learning\\_rate * (g_t + param_{old} * weight\\_decay)
+
+            & param_{new} = param_{old} + V_t
+
+    参数:
+        - **params** (iterable) - 待优化参数构成的 iterable 或定义了参数组的 dict。
+        - **lr** (float, optional) - 学习率（默认值：1e-3）。 
+        - **momentum** (float, optional) - momentum 因子（默认值: 0.0）。
+        - **weight_decay** (float, optional) - 权重衰减（L2 penalty）（默认值: 0.0）。
+
+    示例： 
+
+    例1:：
+
+    .. code-block:: python 
+
+        # 假设 net 是一个自定义模型。
+        sgd = flow.optim.SGD(net.parameters(), lr=1e-3)
+
+        for epoch in range(epochs):
+            # 读取数据，计算损失，等等。
+            # ...
+            loss.backward()
+            sgd.step()
+            sgd.zero_grad()
+
+    例2： 
+
+    .. code-block:: python 
+
+        # 假设 net 是一个自定义模型。
+        sgd = flow.optim.SGD(
+            [
+                {
+                    "params": net.parameters(),
+                    "lr": learning_rate,
+                    "clip_grad_max_norm": 0.5,
+                    "clip_grad_norm_type": 2.0,
+                }
+            ],
+        )
+
+        for epoch in range(epochs):
+            # 读取数据，计算损失，等等。
+            # ...
+            loss.backward()
+            sgd.clip_grad()
+            sgd.step()
+            sgd.zero_grad()
+
+    若要使用 clip_grad 函数，请参考这个示例。
+
+    关于 `clip_grad_max_norm` 和 `clip_grad_norm_type` 函数的更多细节，请参考 :func:`oneflow.nn.utils.clip_grad_norm` 。
+
+    """
+)
+

--- a/docs/source/cn/step_lr.py
+++ b/docs/source/cn/step_lr.py
@@ -5,15 +5,15 @@ reset_docstr(
     oneflow.optim.lr_scheduler.StepLR,
     """
     在每一个 step_size 大小的步骤中，以伽玛衰减每个参数组的学习率。
-    注意，这种衰减可以与本调整器以外的其他学习率变化同时发生。
+    注意，这种衰减可以与本调整器无关的其他的学习率变化同时发生。
     当 last_step = -1 时，设置初始学习率为 lr。
 
     参数:
-        - **optimizer** (Optimizer) - 封装的优化器。
+        - **optimizer** (Optimizer) - 被包装的优化器。
         - **step_size** (int) - 学习率衰减的时间。
         - **gamma** (float, optional) - 学习率衰减的乘法系数（默认：0.1）。
         - **last_step** (int) - 最后一个 epoch 的索引（默认值：-1）。
-        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到 stdout（默认值: ``False`` ）。
+        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到标准输出（默认值: ``False`` ）。
 
     示例：
 

--- a/docs/source/cn/step_lr.py
+++ b/docs/source/cn/step_lr.py
@@ -1,0 +1,38 @@
+import oneflow
+from docreset import reset_docstr
+
+reset_docstr(
+    oneflow.optim.lr_scheduler.StepLR,
+    """
+    在每一个 step_size 大小的步骤中，以伽玛衰减每个参数组的学习率。
+    注意，这种衰减可以与本调整器以外的其他学习率变化同时发生。
+    当 last_step = -1 时，设置初始学习率为 lr。
+
+    参数:
+        - **optimizer** (Optimizer) - 封装的优化器。
+        - **step_size** (int) - 学习率衰减的时间。
+        - **gamma** (float, optional) - 学习率衰减的乘法系数（默认：0.1）。
+        - **last_step** (int) - 最后一个 epoch 的索引（默认值：-1）。
+        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到 stdout（默认值: ``False`` ）。
+
+    示例：
+
+    .. code-block:: python
+
+        import oneflow as flow
+
+        ...
+        step_lr = flow.optim.lr_scheduler.StepLR(optimizer, step_size=30, gamma=0.1)
+        for epoch in range(num_epoch):
+            train(...)
+            step_lr.step()
+
+    """
+)
+
+reset_docstr(
+    oneflow.optim.lr_scheduler.StepLR.get_lr,
+    """
+    利用学习率调整器链式计算学习率。
+    """
+)

--- a/docs/source/cn/step_lr.py
+++ b/docs/source/cn/step_lr.py
@@ -4,16 +4,16 @@ from docreset import reset_docstr
 reset_docstr(
     oneflow.optim.lr_scheduler.StepLR,
     """
-    在每一个 step_size 大小的步骤中，以伽玛衰减每个参数组的学习率。
-    注意，这种衰减可以与本调整器无关的其他的学习率变化同时发生。
+    在每一个周期为 step_size 的步骤中，对每个参数组的学习率进行伽玛衰减操作。
+    注意，这种衰减可以与其他因素导致的学习率变化同时发生。
     当 last_step = -1 时，设置初始学习率为 lr。
 
     参数:
         - **optimizer** (Optimizer) - 被包装的优化器。
-        - **step_size** (int) - 学习率衰减的时间。
+        - **step_size** (int) - 学习率衰减的周期。
         - **gamma** (float, optional) - 学习率衰减的乘法系数（默认：0.1）。
         - **last_step** (int) - 最后一个 epoch 的索引（默认值：-1）。
-        - **verbose** (bool) - 如果为 ``True`` ，则会为每次更新打印一条信息到标准输出（默认值: ``False`` ）。
+        - **verbose** (bool) - 如果为 ``True`` ，则会在每次更新时打印一条信息到标准输出。默认为 ``False``。
 
     示例：
 
@@ -29,5 +29,3 @@ reset_docstr(
 
     """
 )
-
-

--- a/docs/source/cn/step_lr.py
+++ b/docs/source/cn/step_lr.py
@@ -30,9 +30,4 @@ reset_docstr(
     """
 )
 
-reset_docstr(
-    oneflow.optim.lr_scheduler.StepLR.get_lr,
-    """
-    利用学习率调整器链式计算学习率。
-    """
-)
+


### PR DESCRIPTION
[oneflow.optim.RMSprop](https://github.com/Oneflow-Inc/oneflow/blob/c5f52665655e8a1cdac1a0c309dec7af9add7bad/python/oneflow/nn/optimizer/rmsprop.py#L24)
[oneflow.optim.SGD](https://github.com/Oneflow-Inc/oneflow/blob/c5f52665655e8a1cdac1a0c309dec7af9add7bad/python/oneflow/nn/optimizer/sgd.py#L25)
<img width="832" alt="截屏2022-03-24 下午3 09 20" src="https://user-images.githubusercontent.com/69283456/159861877-bd0ae940-30e5-4db9-b5e4-72206fc6e485.png">
<img width="801" alt="截屏2022-03-24 下午3 09 28" src="https://user-images.githubusercontent.com/69283456/159861884-71122cbb-23ae-44e0-a7f9-ab6fda78ffe8.png">
<img width="768" alt="截屏2022-03-24 下午3 09 36" src="https://user-images.githubusercontent.com/69283456/159861891-b1c4c59a-6ae6-4e5e-ae60-95e07a604568.png">

<img width="763" alt="截屏2022-03-24 下午3 09 43" src="https://user-images.githubusercontent.com/69283456/159861899-033fa4c3-5a84-4806-adbe-6821f348db98.png">

[oneflow.optim.CosineAnnealingLR](https://github.com/Oneflow-Inc/oneflow/blob/c5f52665655e8a1cdac1a0c309dec7af9add7bad/python/oneflow/nn/optimizer/cosine_annealing_lr.py#L22)
[oneflow.optim.CosineDecayLR](https://github.com/Oneflow-Inc/oneflow/blob/c5f52665655e8a1cdac1a0c309dec7af9add7bad/python/oneflow/nn/optimizer/cosine_decay_lr.py#L22)

<img width="809" alt="截屏2022-03-24 下午3 10 01" src="https://user-images.githubusercontent.com/69283456/159861916-6807ca61-c1a0-41be-a842-f57c5718fe2c.png">

<img width="784" alt="截屏2022-03-24 下午3 10 13" src="https://user-images.githubusercontent.com/69283456/159861938-940b8fda-18f4-422c-908b-d70e512e41cf.png">
<img width="779" alt="截屏2022-03-24 下午3 10 20" src="https://user-images.githubusercontent.com/69283456/159861963-0c38ecf3-9ffb-4c10-93a8-32b9b7f43228.png">



