### PR TITLE
Refine mathjax cdn

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,7 @@ recommonmark==0.6.0
 jinja2<3.1
 furo==2021.4.11b34
 sphinx-copybutton==0.5.0
+sphinxcontrib-katex==0.8.6
 # above are dev dependencies
 --pre
 --find-links https://staging.oneflow.info/branch/master/cpu

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -192,6 +192,7 @@ autodoc_default_options = {
     "exclude-members": "forward",
 }
 
+mathjax_path = "https://cdn.bootcdn.net/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-AMS-MML_HTMLorMML"
 
 def should_skip_member(app, what, name, obj, skip, options):
     import collections

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,7 +44,7 @@ release = u""
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
-    "sphinxcontrib.katex",
+    #"sphinxcontrib.katex",
     "recommonmark",
     "sphinx_copybutton",
 ]
@@ -198,7 +198,6 @@ autodoc_default_options = {
     "exclude-members": "forward",
 }
 
-mathjax_path = "https://cdn.jsdelivr.net/npm/mathjax@2.7.8/latest.js?config=TeX-AMS-MML_HTMLorMML"
 
 def should_skip_member(app, what, name, obj, skip, options):
     import collections

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -192,7 +192,7 @@ autodoc_default_options = {
     "exclude-members": "forward",
 }
 
-mathjax_path = "https://cdn.bootcdn.net/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-AMS-MML_HTMLorMML"
+mathjax_path = "https://cdn.jsdelivr.net/npm/mathjax@2.7.8/latest.js?config=TeX-AMS-MML_HTMLorMML"
 
 def should_skip_member(app, what, name, obj, skip, options):
     import collections

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,7 +41,13 @@ release = u""
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon", "recommonmark", "sphinx_copybutton"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinxcontrib.katex",
+    "recommonmark",
+    "sphinx_copybutton",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,7 +44,7 @@ release = u""
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
-    #"sphinxcontrib.katex",
+    "sphinxcontrib.katex",
     "recommonmark",
     "sphinx_copybutton",
 ]


### PR DESCRIPTION
sphinx 默认使用的是 mathjax。这个 PR 中换成 kaTex。 实测速度会更快，粗略统计快2倍以上。

KaTex：
![image](https://user-images.githubusercontent.com/3351623/162882283-e5e30547-49c5-4df0-92db-5e7dadcf8483.png)



MathJax：
![image](https://user-images.githubusercontent.com/3351623/162882230-df427455-86d7-4c98-bab7-74bf2cac948a.png)
