### PR TITLE
文档重构测试

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,7 +41,17 @@ release = u""
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon", "recommonmark", "sphinx_copybutton"]
+extensions = [
+    "sphinx.ext.autodoc", 
+    "sphinx.ext.napoleon", 
+    "recommonmark", 
+    "sphinx_copybutton",
+    "sphinx.ext.autosummary"
+    ]
+
+# build the templated autosummary files
+autosummary_generate = True
+numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/source/functional.rst
+++ b/docs/source/functional.rst
@@ -1,45 +1,115 @@
+.. role:: hidden
+    :class: hidden-section
+
 oneflow.nn.functional
 ===========================================
-Functional operations for neural networks
--------------------------------------------
+
 .. currentmodule:: oneflow.nn.functional
-.. autofunction:: conv1d
-.. autofunction:: conv2d
-.. autofunction:: conv3d
-.. autofunction:: adaptive_avg_pool1d
-.. autofunction:: adaptive_avg_pool2d
-.. autofunction:: adaptive_avg_pool3d
-.. autofunction:: relu
-.. autofunction:: hardsigmoid
-.. autofunction:: hardswish
-.. autofunction:: hardtanh
-.. autofunction:: normalize
-.. autofunction:: leaky_relu
-.. autofunction:: elu
-.. autofunction:: celu
-.. autofunction:: selu
-.. autofunction:: sigmoid
-.. autofunction:: pad
-.. autofunction:: prelu
-.. autofunction:: logsigmoid 
-.. autofunction:: log_softmax
-.. autofunction:: gelu
-.. autofunction:: glu
-.. autofunction:: softsign
-.. autofunction:: softmax 
-.. autofunction:: softplus
-.. autofunction:: tanh 
-.. autofunction:: silu
-.. autofunction:: mish
-.. autofunction:: one_hot
-.. autofunction:: triplet_margin_loss
-.. autofunction:: dropout 
-.. autofunction:: upsample
-.. autofunction:: affine_grid
-.. autofunction:: grid_sample
-.. autofunction:: interpolate
-.. autofunction:: layer_norm
-.. autofunction:: ctc_greedy_decoder
-.. autofunction:: sparse_softmax_cross_entropy
-.. autofunction:: embedding
-.. autofunction:: linear
+
+Convolution functions
+-------------------------------------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    conv1d
+    conv2d
+    conv3d
+
+Pooling functions
+----------------------------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    adaptive_avg_pool1d
+    adaptive_avg_pool2d
+    adaptive_avg_pool3d
+
+Non-linear activation functions
+-------------------------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    threshold
+    relu
+    hardtanh
+    elu
+    selu
+    celu
+    leaky_relu
+    prelu
+    glu
+    gelu
+    logsigmoid
+    hardshrink
+    softsign
+    softplus
+    softmax
+    softshrink
+    log_softmax
+    tanh
+    sigmoid
+    hardsigmoid
+    silu
+    mish
+    layer_norm
+    normalize
+
+Linear functions
+----------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    linear
+
+Dropout functions
+-----------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    dropout
+
+Sparse functions
+----------------------------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    embedding
+    one_hot
+
+
+Loss functions
+--------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    sparse_softmax_cross_entropy
+    cross_entropy
+    triplet_margin_loss
+
+Vision functions
+----------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    pad
+    interpolate
+    upsample
+    grid_sample
+    affine_grid
+


### PR DESCRIPTION
- 先对 oneflow.nn.functional 中文版进行文档重构测试，参考 pytorch 文档使用sphinx中的 [autosummary](https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html#generating-stub-pages-automatically) 。会自动生成一个函数表格，并且每个函数有自己独立的页面。
<img width="1338" alt="截屏2022-04-29 下午2 41 57" src="https://user-images.githubusercontent.com/69283456/165896202-00539418-31ca-45fc-95bb-184ccadd8f00.png">

- 目前存在的问题：
1. autosummary 会展示函数 docstring 中的第一句话来介绍函数，而 oneflow 中一些函数 docstring 的首句无法作为函数简介。
<img width="807" alt="截屏2022-04-29 下午2 42 53" src="https://user-images.githubusercontent.com/69283456/165896242-00bef6b1-7e99-4203-9478-3ddfaa005f8e.png">

3. 在 make html 时会在source目录下多生成一个generated目录存放所有函数。
<img width="733" alt="截屏2022-04-29 下午2 43 16" src="https://user-images.githubusercontent.com/69283456/165896285-a29a429f-0607-4c5e-ab6d-54e4552733f0.png">
