### PR TITLE
type_tensor

### DIFF
--- a/docs/source/cn/__init__.py
+++ b/docs/source/cn/__init__.py
@@ -61,3 +61,4 @@ from .step_lr import *
 from .conv import *
 from .normalization import *
 from .vision import *
+from .type_tensor import *

--- a/docs/source/cn/functional1.py
+++ b/docs/source/cn/functional1.py
@@ -386,7 +386,7 @@ reset_docstr(
         ...     labels=labels, logits=logits
         ... )
         >>> output
-        tensor([0.2975, 1.1448, -0.0000], dtype=oneflow.float32)
+        tensor([ 2.9751e-01,  1.1448e+00, -1.4305e-06], dtype=oneflow.float32)
     """
 )
 

--- a/docs/source/cn/type_tensor.py
+++ b/docs/source/cn/type_tensor.py
@@ -1,0 +1,60 @@
+import oneflow
+from docreset import reset_docstr
+
+
+reset_docstr(
+    oneflow.BoolTensor,
+    r"""
+    创建一个张量，其数据类型为布尔型，它的参数与 :func:`oneflow.Tensor` 相同。
+    """,
+)
+
+reset_docstr(
+    oneflow.ByteTensor,
+    r"""
+    创建一个张量，其数据类型为 uint8，它的参数与 :func:`oneflow.Tensor` 相同。
+    """,
+)
+
+reset_docstr(
+    oneflow.CharTensor,
+    r"""
+    创建一个张量，其数据类型为 int8，它的参数与 :func:`oneflow.Tensor` 相同。
+    """,
+)
+
+reset_docstr(
+    oneflow.DoubleTensor,
+    r"""
+    创建一个张量，其数据类型为 float64，它的参数与 :func:`oneflow.Tensor` 相同。
+    """,
+)
+
+reset_docstr(
+    oneflow.FloatTensor,
+    r"""
+    创建一个张量，其数据类型为 float32，它的参数与 :func:`oneflow.Tensor` 相同。
+    """,
+)
+
+reset_docstr(
+    oneflow.HalfTensor,
+    r"""
+    创建一个张量，其数据类型为 float16，它的参数与 :func:`oneflow.Tensor` 相同。
+    """,
+)
+
+reset_docstr(
+    oneflow.LongTensor,
+    r"""
+    创建一个张量，其数据类型为 int64，它的参数与 :func:`oneflow.Tensor` 相同。
+    """,
+)
+
+reset_docstr(
+    oneflow.IntTensor,
+    r"""
+    创建一个张量，其数据类型为 int32，它的参数与 :func:`oneflow.Tensor` 相同。
+    """,
+)
+

--- a/docs/source/cn/type_tensor.py
+++ b/docs/source/cn/type_tensor.py
@@ -5,56 +5,56 @@ from docreset import reset_docstr
 reset_docstr(
     oneflow.BoolTensor,
     r"""
-    创建一个张量，其数据类型为布尔型，它的参数与 :func:`oneflow.Tensor` 相同。
+    创建一个张量，其数据类型为 oneflow.bool，它的参数与 :func:`oneflow.Tensor` 相同。
     """,
 )
 
 reset_docstr(
     oneflow.ByteTensor,
     r"""
-    创建一个张量，其数据类型为 uint8，它的参数与 :func:`oneflow.Tensor` 相同。
+    创建一个张量，其数据类型为 oneflow.uint8，它的参数与 :func:`oneflow.Tensor` 相同。
     """,
 )
 
 reset_docstr(
     oneflow.CharTensor,
     r"""
-    创建一个张量，其数据类型为 int8，它的参数与 :func:`oneflow.Tensor` 相同。
+    创建一个张量，其数据类型为 oneflow.int8，它的参数与 :func:`oneflow.Tensor` 相同。
     """,
 )
 
 reset_docstr(
     oneflow.DoubleTensor,
     r"""
-    创建一个张量，其数据类型为 float64，它的参数与 :func:`oneflow.Tensor` 相同。
+    创建一个张量，其数据类型为 oneflow.float64，它的参数与 :func:`oneflow.Tensor` 相同。
     """,
 )
 
 reset_docstr(
     oneflow.FloatTensor,
     r"""
-    创建一个张量，其数据类型为 float32，它的参数与 :func:`oneflow.Tensor` 相同。
+    创建一个张量，其数据类型为 oneflow.float32，它的参数与 :func:`oneflow.Tensor` 相同。
     """,
 )
 
 reset_docstr(
     oneflow.HalfTensor,
     r"""
-    创建一个张量，其数据类型为 float16，它的参数与 :func:`oneflow.Tensor` 相同。
+    创建一个张量，其数据类型为 oneflow.float16，它的参数与 :func:`oneflow.Tensor` 相同。
     """,
 )
 
 reset_docstr(
     oneflow.LongTensor,
     r"""
-    创建一个张量，其数据类型为 int64，它的参数与 :func:`oneflow.Tensor` 相同。
+    创建一个张量，其数据类型为 oneflow.int64，它的参数与 :func:`oneflow.Tensor` 相同。
     """,
 )
 
 reset_docstr(
     oneflow.IntTensor,
     r"""
-    创建一个张量，其数据类型为 int32，它的参数与 :func:`oneflow.Tensor` 相同。
+    创建一个张量，其数据类型为 oneflow.int32，它的参数与 :func:`oneflow.Tensor` 相同。
     """,
 )
 


### PR DESCRIPTION
[来自这个issue](https://github.com/Oneflow-Inc/oneflow-api-cn/issues/80)：翻译了以下函数

[oneflow.BoolTensor](https://start.oneflow.org/oneflow-api-cn/oneflow.html#oneflow.BoolTensor) , [oneflow.ByteTensor](https://start.oneflow.org/oneflow-api-cn/oneflow.html#oneflow.ByteTensor) , [oneflow.CharTensor](https://start.oneflow.org/oneflow-api-cn/oneflow.html#oneflow.CharTensor) , [oneflow.DoubleTensor](https://start.oneflow.org/oneflow-api-cn/oneflow.html#oneflow.DoubleTensor) , [oneflow.FloatTensor](https://start.oneflow.org/oneflow-api-cn/oneflow.html#oneflow.FloatTensor) , [oneflow.HalfTensor](https://start.oneflow.org/oneflow-api-cn/oneflow.html#oneflow.HalfTensor) , , [oneflow.LongTensor](https://start.oneflow.org/oneflow-api-cn/oneflow.html#oneflow.LongTensor)

补充了该英文文档的中文api
https://github.com/Oneflow-Inc/oneflow/blob/b826253a7f83bae883b0fabf336c40c89cef5991/python/oneflow/framework/type_tensor.py#L33

展示如下

![image](https://user-images.githubusercontent.com/48576019/167366849-4e5b02ab-0688-40a4-bdd4-11c1b5e42de3.png)
